### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/blog/_posts/2012-10-22-messytables.md
+++ b/blog/_posts/2012-10-22-messytables.md
@@ -42,7 +42,7 @@ We've since also started using messytables to load data into the
 where it serves as the ETL for the datastore and related
 [ReclineJS](http://reclinejs.com/) previews.
 
-If you're interested, check out the [messytables documentation](http://messytables.readthedocs.org/en/latest/index.html)
+If you're interested, check out the [messytables documentation](https://messytables.readthedocs.io/en/latest/index.html)
 and the [uk25k scripts](https://github.com/openspending/dpkg-uk25k/blob/master/extract.py)
 which use it to gather UK government finance. 
 
@@ -52,7 +52,7 @@ data.
 * [tablib](http://docs.python-tablib.org/en/latest/), for example, has
 a fantastic API that makes writing, analyzing and converting data a
 breeze.
-* [csvkit](http://csvkit.readthedocs.org/en/latest/index.html) has a
+* [csvkit](https://csvkit.readthedocs.io/en/latest/index.html) has a
 set of command line utilities that should be pre-installed on any
 computer.
 

--- a/projects/index.html
+++ b/projects/index.html
@@ -22,7 +22,7 @@ description:
         a social network analysis toolkit for news applications.
       </li>
       <li><span class="date">2012-2014</span>
-        <span class="title"><a href="http://dataset.readthedocs.org/en/latest/">dataset</a></span>,
+        <span class="title"><a href="https://dataset.readthedocs.io/en/latest/">dataset</a></span>,
         easy-to-use Python library for data processing using relational databases.
       </li>
       <li><span class="date">2012-2015</span>
@@ -70,7 +70,7 @@ description:
         <a href="http://data.gov.uk/data/openspending-browse">data.gov.uk spend browser</a>.
       </li>
       <li><span class="date">2011-2013</span>
-        <span class="title"><a href="http://messytables.readthedocs.org/">messytables</a></span>, extracting structured
+        <span class="title"><a href="https://messytables.readthedocs.io/">messytables</a></span>, extracting structured
         data from badly-formatted tabular data.
       </li>
       <li><span class="date">2012-2013</span>
@@ -79,7 +79,7 @@ description:
         and Friends of the Earth Europe.
       </li>
       <li><span class="date">2011</span>
-        <span class="title"><a href="http://webstore.readthedocs.org/en/latest/">WebStore</a></span>, RESTful,
+        <span class="title"><a href="https://webstore.readthedocs.io/en/latest/">WebStore</a></span>, RESTful,
         SQL-based data store and API generator service.
       </li>
       <li><span class="date">2011</span>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
